### PR TITLE
Added support for stores that already have lat and lng TVs

### DIFF
--- a/core/components/googlestorelocator/elements/snippets/googlestorelocator.snippet.php
+++ b/core/components/googlestorelocator/elements/snippets/googlestorelocator.snippet.php
@@ -16,6 +16,8 @@ $modx->loadClass('GoogleStoreLocator', $modelPath, true, true);
 
 // Configuration parameters
 $config['parents'] = array_unique(explode(',', $modx->getOption('parents', $scriptProperties, $modx->resource->get('id'), true)));
+$config['tvname_lat'] = $modx->getOption('tvNameLat', $scriptProperties, 'gslLat', true);
+$config['tvname_lng'] = $modx->getOption('tvNameLng', $scriptProperties, 'gslLng', true);
 $config['tvname_zipcode'] = $modx->getOption('tvNameZipcode', $scriptProperties, 'gslZipcode', true);
 $config['tvname_city'] = $modx->getOption('tvNameCity', $scriptProperties, 'gslCity', true);
 $config['tvname_street'] = $modx->getOption('tvNameStreet', $scriptProperties, 'gslStreet', true);

--- a/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php
+++ b/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php
@@ -18,6 +18,8 @@ class GoogleStoreLocator {
         $this->apikeyServer = $this->modx->getOption('googlestorelocator.apikey_server');
         $this->apikeyMap = $this->modx->getOption('googlestorelocator.apikey_map');
         $this->parents = $config['parents'];
+        $this->tvname_lat = $config['tvname_lat'];
+        $this->tvname_lng = $config['tvname_lng'];
         $this->tvname_street = $config['tvname_street'];
         $this->tvname_housenumber = $config['tvname_housenumber'];
         $this->tvname_zipcode = $config['tvname_zipcode'];
@@ -97,6 +99,8 @@ class GoogleStoreLocator {
             $store = array(
                 'id' => $item->id,
                 'name' => $item->pagetitle,
+                'lat' => $page->getTVValue($this->tvname_lat),
+                'lng' => $page->getTVValue($this->tvname_lng),
                 'street' => $page->getTVValue($this->tvname_street),
                 'housenumber' => $page->getTVValue($this->tvname_housenumber),
                 'zipcode' => $page->getTVValue($this->tvname_zipcode),

--- a/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php
+++ b/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php
@@ -309,6 +309,9 @@ class GoogleStoreLocator {
 
         $stores = array_filter($stores, function ($var) {
             switch ($this->operator) {
+                case 'contains':
+                    return strpos($var[$this->key], $this->value) !== false;
+                    break;
                 case '==':
                 case '=':
                     return ($var[$this->key] == $this->value);

--- a/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php
+++ b/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php
@@ -242,6 +242,7 @@ class GoogleStoreLocator {
         if (!empty($_REQUEST['location'])) {
             $message = $this->modx->getChunk($this->tpl_message, array(
                 'address' => $locationData['address'],
+                'radius' => $radius,
             ));
 
             $this->modx->toPlaceholders(array(

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,8 @@ Since the latest version of Google-API: API-KEY(s) are required! Create a API-KE
 | &tvNameHousenumber | gslHousenumber | Name of the TV holding the Housenumber of the Store. |
 | &tvNameState | gslState | Name of the TV holding the State of the Store. |
 | &tvNameCountry | gslCountry | Name of the TV holding the Country of the Store. |
+| &tvNameLat | gslLat | Name of the TV holding the Latitude of the Store (to skip geocoding). |
+| &tvNameLng | gslLng | Name of the TV holding the Longitude of the Store (to skip geocoding). |
 | &includeTVs |  | Comma-separated list of TVs that should be included in the placeholders available to each store template. Example: "storename,time" will produce the placeholders and . |
 | &tvPrefix | tv. | Prefix TV property. |
 | &unit | K | Options: K = kilometers / M = miles / N = nautical |
@@ -124,6 +126,7 @@ If you have more than 50 stores the initail rendering of all stores will take a 
 I tested the extra with about 1500 stores. The first rendering took about 4 refreshes and 1 Minute in between every refresh. After that: everything runs smooth.
 Change a store/resource in the manager will delete this store from the cache and will be rewritten after the next request of the StoreLocation snippet. This won't take long, because it is just rendering the new added or changed stores.
 If you manually clear the complete site-cache it also clears the GoogleStoreLocator cache and it needs a new rendering of all stores.
+If your store resources already have latitude and longitude TVs, specify them with the `&tvNameLat` and `&tvNameLng` properties to skip the overhead of geocoding the addresses.
 
 # Upgrading from Version 1.x to 2.x
 Upgrading from Version 1.x to 2.x needs some little Changes in the propertie-setup.


### PR DESCRIPTION
In my case, my store resources already have `lat` and `lng` TVs, and because of where I live in the world, the street addresses don't geocode well anyway.  So the simple solution is to add `&tvNameLat` and `&tvNameLng` parameters to the snippet, so if the latitude and longitude can be resolved by already stored TV values, then there is no need to geocode the messy addresses.

