### PR TITLE
Fix PHP 7.2 warnings

### DIFF
--- a/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php
+++ b/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php
@@ -377,8 +377,8 @@ class GoogleStoreLocator {
         $options = array(
             xPDO::OPT_CACHE_KEY => 'googlestorelocator',
         );
-        $this->modx->cacheManager->delete($store[id] . '.store.gsl', $options);
-        $this->modx->cacheManager->set($store[id] . '.store.gsl', $store, 31556926, $options);
+        $this->modx->cacheManager->delete($store['id'] . '.store.gsl', $options);
+        $this->modx->cacheManager->set($store['id'] . '.store.gsl', $store, 31556926, $options);
 
     }
 


### PR DESCRIPTION
This is logged when running under PHP 7.2:

```log
[2019-05-05 14:41:38] (ERROR @ /[...]/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php : 380) PHP warning: Use of undefined constant id - assumed 'id' (this will throw an Error in a future version of PHP)
[2019-05-05 14:41:38] (ERROR @ /[...]/core/components/googlestorelocator/model/googlestorelocator/googlestorelocator.class.php : 381) PHP warning: Use of undefined constant id - assumed 'id' (this will throw an Error in a future version of PHP)
```

So this fix!